### PR TITLE
make dockerhub deploys to latest possible

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ push-image: build-image
 
 .PHONY: push-latest
 push-latest: build-image
-	$(DOCKER) $(DOCKER_OPTS) tag $(DOCKER_IMAGE_NAME) $(ORG)/$(NAME):latest
+	$(DOCKER) $(DOCKER_OPTS) tag -f $(DOCKER_IMAGE_NAME) $(ORG)/$(NAME):latest
 	$(DOCKER) $(DOCKER_OPTS) push $(ORG)/$(NAME):latest
 
 .PHONY: context


### PR DESCRIPTION
Fixed problem where latest would have already been built and `-f` had to be used to override. It looks like this will be eventually deprecated.