### PR TITLE
gofmt -s -w

### DIFF
--- a/pkg/localkubectl/localkubectl.go
+++ b/pkg/localkubectl/localkubectl.go
@@ -38,7 +38,7 @@ func Command(out io.Writer) *cli.Command {
 				Description: "Starts the localkube cluster",
 				Flags: []cli.Flag{
 					cli.StringFlag{
-						Name: "t",
+						Name:  "t",
 						Value: LocalkubeDefaultTag,
 						Usage: "specifies localkube image tag to use, default is latest",
 					},
@@ -93,7 +93,7 @@ func Command(out io.Writer) *cli.Command {
 				Description: "Stops the localkube cluster",
 				Flags: []cli.Flag{
 					cli.BoolFlag{
-						Name: "r",
+						Name:  "r",
 						Usage: "removes container",
 					},
 				},


### PR DESCRIPTION
`make` wouldn't run successfully without this file being formatted.

I'm not sure how the previous travis run passed, because when I run `make docker-build run-image`, I get:

```
± make docker-build run-image
# get all go files and run go fmt on them
Error: 'gofmt -s' needs to be run on:
./pkg/localkubectl/localkubectl.go
make: *** [checkgofmt] Error 1
```