### PR TITLE
Add a flag to control whether the kubelet runs in "containerized" mode.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,10 +51,18 @@ integration: build-image
 .PHONY: build
 build: build/localkube-$(GOOS)
 
+.PHONY: build-dynamic
+build-dynamic: build/localkube-dynamic-$(GOOS)
+
 .PHONY: docker-build
 docker-build: validate
 	mkdir build
 	$(DOCKER) run -w $(DOCKER_DIR) $(DOCKER_OPTS) $(MNT_REPO) $(DOCKER_DEV_IMAGE) make build
+
+.PHONY: docker-build-dynamic
+docker-build-dynamic: validate
+	mkdir build
+	$(DOCKER) run -w $(DOCKER_DIR) $(DOCKER_OPTS) $(MNT_REPO) $(DOCKER_DEV_IMAGE) make build-dynamic
 
 .PHONY: clean
 clean:
@@ -62,6 +70,9 @@ clean:
 
 build/localkube-$(GOOS):
 	$(GO) build -o $@ $(GOBUILD_FLAGS) $(GOBUILD_LDFLAGS) $(EXEC_PKG)
+
+build/localkube-dynamic-$(GOOS):
+	CGO_ENABLED=1 $(GO) build -o $@ $(EXEC_PKG)
 
 .PHONY: build-image
 build-image: context

--- a/cmd/localkube/main.go
+++ b/cmd/localkube/main.go
@@ -68,7 +68,7 @@ func main() {
 
 	// if first
 	load()
-	err := LK.Run(os.Args, os.Stderr)
+	err := LK.Run(os.Stderr)
 	if err != nil {
 		fmt.Printf("localkube errored: %v\n", err)
 		os.Exit(1)

--- a/kubelet.go
+++ b/kubelet.go
@@ -35,7 +35,7 @@ func StartKubeletServer(clusterDomain, clusterDNS string) func() {
 	config.APIServerList = []string{APIServerURL}
 
 	// Docker
-	config.Containerized = true
+	config.Containerized = *containerized
 	config.DockerEndpoint = WeaveProxySock
 
 	// Networking

--- a/localkube.go
+++ b/localkube.go
@@ -2,6 +2,7 @@ package localkube
 
 import (
 	"errors"
+	"flag"
 	"fmt"
 	"io"
 )
@@ -15,20 +16,28 @@ func (lk *LocalKube) Add(server Server) {
 	lk.Servers = append(lk.Servers, server)
 }
 
-func (lk *LocalKube) Run(args []string, out io.Writer) error {
-	if len(args) < 2 {
+var containerized = flag.Bool("containerized", true, "Whether localkube is inside a container or not")
+
+func init() {
+	flag.Parse()
+}
+
+func (lk *LocalKube) Run(out io.Writer) error {
+	if len(flag.Args()) < 1 {
 		return errors.New("you must choose start <name>, stop <name>, or status")
 	}
 
-	switch args[1] {
+	args := flag.Args()
+	fmt.Fprintln(out, "Got args: %s", args)
+	switch args[0] {
 	case "start":
 		// check if just start
-		if len(args) == 2 {
+		if len(args) == 1 {
 			fmt.Fprintln(out, "Starting LocalKube...")
 			lk.StartAll()
 			return nil
-		} else if len(args) == 3 {
-			serverName := args[2]
+		} else if len(args) == 2 {
+			serverName := args[1]
 			fmt.Fprintf(out, "Starting `%s`...\n", serverName)
 			return lk.Start(serverName)
 
@@ -37,12 +46,12 @@ func (lk *LocalKube) Run(args []string, out io.Writer) error {
 		}
 	case "stop":
 		// check if just stop
-		if len(args) == 2 {
+		if len(args) == 1 {
 			fmt.Fprintln(out, "Stopping LocalKube...")
 			lk.StopAll()
 			return nil
-		} else if len(args) == 3 {
-			serverName := args[2]
+		} else if len(args) == 2 {
+			serverName := args[1]
 			fmt.Fprintf(out, "Stopping `%s`...\n", serverName)
 			return lk.Stop(serverName)
 		}


### PR DESCRIPTION
This also adds a build mode for "dynamic" compilation instead of static. This is required for cAdvisor to run in the "non-containerized" kubelet.

FYI, this is part of the minikube project: https://github.com/kubernetes/minikube/issues/8
