### PR TITLE
Allow configMaps to be mounted as volumes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ DOCKER_DIR := /go/src/$(PKG)
 MNT_ROOT ?= -v "/:/rootfs:ro"
 MNT_SYS ?= -v "/sys:/sys:rw"
 MNT_DOCKER_LIB ?= -v "/var/lib/docker:/var/lib/docker" -v "/mnt/sda1/var/lib/docker:/mnt/sda1/var/lib/docker"
-MNT_KUBELET_LIB ?= -v "/var/lib/kubelet:/var/lib/kubelet"
+MNT_KUBELET_LIB ?= -v "/var/lib/kubelet:/var/lib/kubelet:rw,shared"
 MNT_RUN ?= -v "/var/run:/var/run:rw"
 
 MNT_REPO ?= -v "$(mkfile_dir):$(DOCKER_DIR)"

--- a/pkg/localkubectl/controller.go
+++ b/pkg/localkubectl/controller.go
@@ -156,7 +156,7 @@ func (d *Controller) StartCtr(ctrId, etcdDataDir string) error {
 		"/sys:/sys:rw",
 		"/var/lib/docker:/var/lib/docker",
 		"/mnt/sda1/var/lib/docker:/mnt/sda1/var/lib/docker",
-		"/var/lib/kubelet:/var/lib/kubelet",
+		"/var/lib/kubelet:/var/lib/kubelet:rw,shared",
 		"/var/run:/var/run:rw",
 		"/:/rootfs:ro",
 	}


### PR DESCRIPTION
See the answer to this SO question:

[http://stackoverflow.com/questions/36187624/kubernetes-configmap-volume-doesnt-create-file-in-container](http://stackoverflow.com/questions/36187624/kubernetes-configmap-volume-doesnt-create-file-in-container)